### PR TITLE
 Fix app crash when BLE is disabled on application start

### DIFF
--- a/app/src/androidTest/java/com/ublox/BLE/TestDevicesActivity.java
+++ b/app/src/androidTest/java/com/ublox/BLE/TestDevicesActivity.java
@@ -39,7 +39,7 @@ public class TestDevicesActivity {
     public ActivityTestRule<DevicesActivity> act = new ActivityTestRule<>(DevicesActivity.class);
 
     @Rule
-    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_COARSE_LOCATION);
+    public GrantPermissionRule permissionRule = GrantPermissionRule.grant(Manifest.permission.ACCESS_FINE_LOCATION);
 
     @Ignore("Requires real hardware to test...")
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,7 @@
 	<uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.BLUETOOTH"/>
 	<uses-permission android:name="android.permission.BLUETOOTH_ADMIN"/>
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 	<uses-feature android:name="android.hardware.bluetooth_le" android:required="true"/>
 	<application android:allowBackup="true" android:icon="@drawable/appicon" android:label="@string/app_name"
 		 android:theme="@style/AppTheme">

--- a/app/src/main/java/com/ublox/BLE/activities/DevicesActivity.java
+++ b/app/src/main/java/com/ublox/BLE/activities/DevicesActivity.java
@@ -32,7 +32,7 @@ import com.ublox.BLE.interfaces.BluetoothDeviceRepresentation;
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
 import static android.bluetooth.BluetoothDevice.BOND_BONDED;
 import static android.bluetooth.BluetoothDevice.BOND_BONDING;
 import static android.bluetooth.BluetoothDevice.BOND_NONE;
@@ -167,10 +167,10 @@ public class DevicesActivity extends Activity implements AdapterView.OnItemClick
 
     @TargetApi(23)
     private void verifyPermissionAndScan() {
-        if (ContextCompat.checkSelfPermission(this, ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(this, ACCESS_FINE_LOCATION) == PERMISSION_GRANTED) {
             scanner.scan(new ArrayList<>());
         } else {
-            requestPermissions(new String[] {ACCESS_COARSE_LOCATION}, LOCATION_REQUEST);
+            requestPermissions(new String[] {ACCESS_FINE_LOCATION}, LOCATION_REQUEST);
         }
     }
 

--- a/app/src/main/java/com/ublox/BLE/activities/DevicesActivity.java
+++ b/app/src/main/java/com/ublox/BLE/activities/DevicesActivity.java
@@ -43,7 +43,6 @@ public class DevicesActivity extends Activity implements AdapterView.OnItemClick
     private static final String TAG = DevicesActivity.class.getSimpleName();
     private static final int LOCATION_REQUEST = 255;
     private LeDeviceListAdapter mLeDeviceListAdapter;
-    private BluetoothAdapter mBluetoothAdapter;
     private BluetoothCentral scanner;
 
     private static final int REQUEST_ENABLE_BT = 1;
@@ -64,17 +63,7 @@ public class DevicesActivity extends Activity implements AdapterView.OnItemClick
             finish();
         }
 
-        final BluetoothManager bluetoothManager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
-        mBluetoothAdapter = bluetoothManager.getAdapter();
-
-        // Checks if Bluetooth is supported on the device.
-        if (mBluetoothAdapter == null) {
-            Toast.makeText(this, R.string.error_bluetooth_not_supported, Toast.LENGTH_SHORT).show();
-            finish();
-        }
-
-        scanner = new BluetoothScanner(mBluetoothAdapter);
-        scanner.setDelegate(this);
+        scanner = null;
     }
 
     @Override
@@ -119,14 +108,24 @@ public class DevicesActivity extends Activity implements AdapterView.OnItemClick
     protected void onResume() {
         super.onResume();
 
+        final BluetoothManager bluetoothManager = (BluetoothManager) getSystemService(Context.BLUETOOTH_SERVICE);
+        BluetoothAdapter bluetoothAdapter = bluetoothManager.getAdapter();
+
+        // Checks if Bluetooth is supported on the device.
+        if (bluetoothAdapter == null) {
+            Toast.makeText(this, R.string.error_bluetooth_not_supported, Toast.LENGTH_SHORT).show();
+            finish();
+        }
+
         // Ensures Bluetooth is enabled on the device.  If Bluetooth is not currently enabled,
         // fire an intent to display a dialog asking the user to grant permission to enable it.
-        if (!mBluetoothAdapter.isEnabled()) {
-            if (!mBluetoothAdapter.isEnabled()) {
-                Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
-                startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
-            }
+        if (!bluetoothAdapter.isEnabled()) {
+            Intent enableBtIntent = new Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE);
+            startActivityForResult(enableBtIntent, REQUEST_ENABLE_BT);
         }
+
+        scanner = new BluetoothScanner(bluetoothAdapter);
+        scanner.setDelegate(this);
 
         // Initializes list view adapter.
         mLeDeviceListAdapter = new LeDeviceListAdapter();


### PR DESCRIPTION
* Move BLE scanner setup after checking whether BLE is activated;
* Require ACCESS_FINE_LOCATION for BLE. According to Android docs having coarse location access is not enough for Android 10: https://developer.android.com/guide/topics/connectivity/bluetooth-le.html#permissions